### PR TITLE
Issue with missing reference to Examine dll in compiled razor code

### DIFF
--- a/Src/Our.Umbraco.ezSearch/Web/UI/Views/MacroPartials/ezSearch.cshtml
+++ b/Src/Our.Umbraco.ezSearch/Web/UI/Views/MacroPartials/ezSearch.cshtml
@@ -1,6 +1,7 @@
-﻿@using System.Globalization
+@using System.Globalization
 @using System.Text
 @using System.Text.RegularExpressions
+@using Examine
 @using Umbraco.Core.Logging
 @using Umbraco.Web.Models
 @inherits Umbraco.Web.Macros.PartialViewMacroPage


### PR DESCRIPTION
To fix issues with at maximum 7.0.4 issue could exist before this. Something do do with needing a reference to examine
