### PR TITLE
Update ezSearchBoostrapper.cs

### DIFF
--- a/Src/Our.Umbraco.ezSearch/Web/UI/App_Code/ezSearchBoostrapper.cs
+++ b/Src/Our.Umbraco.ezSearch/Web/UI/App_Code/ezSearchBoostrapper.cs
@@ -37,13 +37,6 @@ namespace Our.Umbraco.ezSearch
                 e.Fields["searchPath"] = e.Fields["path"].Replace(',', ' ');
             }
 
-            // Lowercase all the fields for case insensitive searching
-            var keys = e.Fields.Keys.ToList();
-            foreach (var key in keys)
-            {
-                e.Fields[key] = HttpUtility.HtmlDecode(e.Fields[key].ToLower(CultureInfo.InvariantCulture));
-            }
-
             // Extract the filename from media items
             if(e.Fields.ContainsKey("umbracoFile"))
             {


### PR DESCRIPTION
Remove force field values to lower case.

The Umbraco ExternalSearcher analyser (based on the Lucene standard analyser I believe) already applies a lowercase filter so this is not necessary. Forcing the field values to lower case breaks other packages (e.g uBlogsy)
