### PR TITLE
Escape special chars so ezSearch doesn't brake anymore

### DIFF
--- a/Src/Our.Umbraco.ezSearch/Web/UI/Views/MacroPartials/ezSearch.cshtml
+++ b/Src/Our.Umbraco.ezSearch/Web/UI/Views/MacroPartials/ezSearch.cshtml
@@ -323,7 +323,7 @@
     {
         return Regex.Matches(input, @"[\""].+?[\""]|[^ ]+")
             .Cast<Match>()
-            .Select(m => m.Value.Trim('\"'))
+            .Select(m => QueryParser.Escape(m.Value.Trim('\"')))
             .ToList();
     }
 


### PR DESCRIPTION
Hi Matt,

I got some errors when people used special characters in their searchterm. In this PR I escaped those.

Cheers,

Dennis
